### PR TITLE
Create package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "airports",
+  "version": "1.0.0",
+  "description": "A JSON array of Airport names, IATA code and location",
+  "main": "airports.json",
+  "files": [
+    "airports.json"
+  ],
+  "engines": {
+    "node": ">=0.10.0"
+  },
+  "keyword": [
+    "airport",
+    "heliport",
+    "iata",
+    "poi",
+    "location",
+    "coordinates",
+    "json",
+    "list",
+    "array"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jbrooksuk/JSON-Airports"
+  },
+  "author": "James Brooks <jbrooksuk@me.com> (https://james-brooks.uk/)",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/jbrooksuk/JSON-Airports/issues"
+  },
+  "homepage": "https://github.com/jbrooksuk/JSON-Airports",
+  "dependencies": {}
+}


### PR DESCRIPTION
Would be create to publish each revision of the JSON file to [npm](https://npmjs.org/).

Hope the details of the `package.json` file is correct, all you need to do after the merge is to run:
```
$ npm publish
```

Of course this would also mean that you sometimes would have to regular releases published to [npm](https://npmjs.org/).

----

I created [airport-codes](https://github.com/matiassingers/airport-codes) temporarily, so I could build [airport-lookup](https://github.com/matiassingers/airport-lookup). Would love to delete and unpublish airport-codes and rely directly on this package.