### PR TITLE
Updated Airport for Grenada (GND)

### DIFF
--- a/airports.json
+++ b/airports.json
@@ -56547,7 +56547,7 @@
         "lon": "-61.78611",
         "iso": "GD",
         "status": 1,
-        "name": "Point Salines International Airport",
+        "name": "Maurice Bishop International Airport",
         "continent": "NA",
         "type": "airport",
         "lat": "12.004167",


### PR DESCRIPTION
Point Salines International was renamed to Maurice Bishop International a few years ago and I updated the airport name for IATA Code "GND" to suit this change.